### PR TITLE
13 minigame frame

### DIFF
--- a/src/EnvironmentManagement/EnvironmentManager.py
+++ b/src/EnvironmentManagement/EnvironmentManager.py
@@ -35,6 +35,8 @@ from VehicleManagement.FleetController import FleetController
 from LocationService.LocationService import LocationService
 from LocationService.TrackPieces import FullTrack
 
+from Minigames.Minigame_Controller import Minigame_Controller
+
 logger = logging.getLogger(__name__)
 
 
@@ -135,7 +137,7 @@ class EnvironmentManager:
 
     def _publish_removed_player(self, player_id: str, reason: RemovalReason = RemovalReason.NONE) -> bool:
         """
-        Sends which player has been removed from the game to the staff ui using a callback function.
+        Sends which player has been removed from the game to the staff ui using a callback function and to the Minigame_Controller instance.
 
         Parameters
         ----------
@@ -163,6 +165,8 @@ class EnvironmentManager:
             message = "Your player was removed from the game, because your playing time is over."
         elif reason is RemovalReason.CAR_DISCONNECTED:
             message = "You were removed since your car wasn't reachable anymore"
+
+        Minigame_Controller.get_instance().handle_player_removed(player_id)
 
         if not callable(self.__publish_removed_player_callback):
             logger.critical('Missing publish_removed_player_callback!')

--- a/src/Minigames/Minigame.py
+++ b/src/Minigames/Minigame.py
@@ -1,0 +1,61 @@
+from quart import Blueprint, render_template, request
+import uuid
+import logging
+import asyncio
+import time
+
+from socketio import AsyncServer
+from abc import abstractmethod
+
+class Minigame:
+
+    def __init__(self, sio: AsyncServer, blueprint : Blueprint, name=__name__):
+        self.minigame_ui_blueprint: Blueprint = blueprint
+        self._sio: AsyncServer = sio
+        if "." in name:
+            name = name.split(".")[-1]
+
+        async def home_minigame() -> str:
+            """
+            Load this minigame's ui page.
+
+            Gets the clients cookie for identification, provides GUI for minigame.
+
+            Returns
+            -------
+                Returns a Response object representing a redirect to the minigame ui page.
+            """
+            player = request.cookies.get("player")
+            if player is None:
+                player = str(uuid.uuid4())
+
+            return await render_template(template_name_or_list=name + '.html', player=player)
+        print(name)
+        self.minigame_ui_blueprint.add_url_rule(f'/{name}', name, view_func=home_minigame)
+
+    @abstractmethod
+    async def play(player1 : str, player2 : str = None) -> str:
+        """
+        Starts the minigame with the given player ids. When done returns the winner of the game.
+
+        Parameters
+        ----------
+        player1: The ID of the first player
+        player2: The ID of the second player. None if the the second player should be a bot
+
+        Returns
+        ----------
+        ID of the victor
+        """
+
+    @abstractmethod
+    def cancel() -> None:
+        """
+        Immediately Cancels the game without winner or loser.
+        """
+
+    @abstractmethod
+    def description() -> str:
+        """
+        Returns a very short description of the game / how to play it.
+        """

--- a/src/Minigames/Minigame.py
+++ b/src/Minigames/Minigame.py
@@ -12,9 +12,9 @@ class Minigame:
     def __init__(self, sio: AsyncServer, blueprint : Blueprint, name=__name__):
         self.minigame_ui_blueprint: Blueprint = blueprint
         self._sio: AsyncServer = sio
-        self.name = name
+        self._name = name
         if "." in name:
-            self.name = name.split(".")[-1]
+            self._name = name.split(".")[-1]
         self._players : list[str] = []
         self._task = None
 
@@ -32,9 +32,9 @@ class Minigame:
             if player is None:
                 player = str(uuid.uuid4())
 
-            return await render_template(template_name_or_list=self.name + '.html', player = player)
+            return await render_template(template_name_or_list=self._name + '.html', player = player)
             
-        self.minigame_ui_blueprint.add_url_rule(f'/{self.name}', self.name, view_func=home_minigame)
+        self.minigame_ui_blueprint.add_url_rule(f'/{self._name}', self._name, view_func=home_minigame)
 
     async def play(self, *players : str) -> str:
         """
@@ -87,3 +87,6 @@ class Minigame:
         Returns a list of the IDs of the players that were selected for this minigame
         """
         return self._players.copy()
+
+    def get_name(self) -> str:
+        return self._name

--- a/src/Minigames/Minigame.py
+++ b/src/Minigames/Minigame.py
@@ -29,8 +29,8 @@ class Minigame:
             if player is None:
                 player = str(uuid.uuid4())
 
-            return await render_template(template_name_or_list=name + '.html', player=player)
-        print(name)
+            return await render_template(template_name_or_list=name + '.html', player = player)
+            
         self.minigame_ui_blueprint.add_url_rule(f'/{name}', name, view_func=home_minigame)
 
     @abstractmethod

--- a/src/Minigames/Minigame.py
+++ b/src/Minigames/Minigame.py
@@ -16,6 +16,7 @@ class Minigame:
         if "." in name:
             self.name = name.split(".")[-1]
         self._players : list[str] = []
+        self._task = None
 
         async def home_minigame() -> str:
             """
@@ -35,8 +36,23 @@ class Minigame:
             
         self.minigame_ui_blueprint.add_url_rule(f'/{self.name}', self.name, view_func=home_minigame)
 
-    @abstractmethod
     async def play(self, *players : str) -> str:
+        """
+        Starts the task of playing the minigame 
+
+        Parameters
+        ----------
+        *players: The ID of the first player
+
+        Returns
+        ----------
+        ID of the victor
+        """
+        self._task = asyncio.create_task(self._play(*players))
+        return await self._task
+
+    @abstractmethod
+    async def _play(self, *players : str) -> str:
         """
         Starts the minigame with the given player ids. When done returns the winner of the game.
         Should redirect the players from the driver UI to the minigame UI and back to the driver UI once the minigame is finished.
@@ -52,11 +68,13 @@ class Minigame:
         ID of the victor
         """
 
-    @abstractmethod
     def cancel(self) -> None:
         """
         Immediately Cancels the game without winner or loser.
         """
+        print("MINIGAQME CANCELLED")
+        self._players.clear()
+        self._task.cancel()
 
     @abstractmethod
     def description(self) -> str:
@@ -64,8 +82,8 @@ class Minigame:
         Returns a very short description of the game / how to play it.
         """
 
-    @abstractmethod
     def get_players(self) -> list[str]:
         """
         Returns a list of the IDs of the players that were selected for this minigame
         """
+        return self._players.copy()

--- a/src/Minigames/Minigame_Controller.py
+++ b/src/Minigames/Minigame_Controller.py
@@ -112,7 +112,7 @@ class Minigame_Controller:
         else:
             return minigame_object.description()
 
-    def play_random_available_minigame(self, *players : str) -> asyncio.Task | None:
+    def play_random_available_minigame(self, *players : str):
         """
         Play a random available minigame with the specified players. 
 
@@ -123,7 +123,7 @@ class Minigame_Controller:
         
         Returns:
         --------
-        asyncio.Task: Task of the running game. Will return the winner's uuid once finished or None if cancelled
+        (asyncio.Task, Minigame): Task of the running game and object/instance of it. Will return the winner's uuid once finished or None if cancelled
         None: if the minigame could not be started for some reason
         """
         if len(self._available_minigames) == 0:
@@ -132,7 +132,7 @@ class Minigame_Controller:
 
         return self._play_minigame(minigame, *players)
 
-    def _play_minigame(self, minigame : str, *players : str) -> (asyncio.Task, Minigame) | None:
+    def _play_minigame(self, minigame : str, *players : str):
         """
         Create an asyncio of the minigame playing with the specified players.
 
@@ -163,7 +163,7 @@ class Minigame_Controller:
         running_game_task : asyncio.Task = asyncio.create_task(minigame_object.play(*players))
         running_game_task.add_done_callback(self._minigame_done_callback(minigame_object))
 
-        return running_game_task
+        return running_game_task, minigame_object
 
     def _minigame_done_callback(self, minigame_object : Minigame) -> None:
         """
@@ -175,3 +175,25 @@ class Minigame_Controller:
             The minigame object/instance that is done
         """
         self._available_minigames.append(minigame_object.get_name())
+
+    def get_minigame_name_by_player_id(self, player_id : str) -> str | None:
+        """
+        Returns the name of the minigame that the specified player is currently associated with.
+
+        Parameters:
+        -----------
+        player_id: str
+            UUID of the player
+
+        Returns:
+        --------
+        str: Name of the minigame the player is participating in
+        None: If the player is not currently participating in any minigames
+        """
+        if player_id is None:
+            return None
+
+        for minigame_object in self._minigame_objects.values():
+            if player_id in minigame_object.get_players():
+                return minigame_object.get_name()
+        return None

--- a/src/Minigames/Minigame_Controller.py
+++ b/src/Minigames/Minigame_Controller.py
@@ -1,0 +1,177 @@
+from quart import Blueprint
+import asyncio
+import random
+
+from socketio import AsyncServer
+
+from EnvironmentManagement.ConfigurationHandler import ConfigurationHandler
+
+from Minigames.Minigame import Minigame
+from Minigames.Minigame_Test import Minigame_Test
+
+class Minigame_Controller:
+
+    instance : "Minigame_Controller" = None
+    minigames : dict = {"Minigame_Test" : Minigame_Test}
+
+    def __init__(self, sio: AsyncServer = None, minigame_ui_blueprint : Blueprint = None):
+        """
+        Behaves like a Singleton. If an instance has already been created, it will be returned. Otherwise the __init__ will be excecuted and the new instance returned
+
+        Parameters:
+        -----------
+        minigame_ui_blueprint: Blueprint
+            The blueprint of the minigame ui
+        """
+        if minigame_ui_blueprint is None:
+            raise Exception("The minigame ui blueprint was not provided. Cancelling the Minigame_Controller.__init__.")
+        if sio is None:
+            raise Exception("No AsyncServer was provided. Cancelling the Minigame_Controller.__init__.")
+        
+        self._config_handler: ConfigurationHandler = ConfigurationHandler()
+        try:
+            self._driving_speed_while_playing = self._config_handler.get_configuration()['minigame']['driving_speed_while_playing']
+        except KeyError:
+            logger.warning("No valid value for minigame: driving_speed_while_playing in config_file. Using default value of 30")
+            self._driving_speed_while_playing = 30
+    
+        try:
+            self.__driver_heartbeat_timeout: int = int(self._config_handler.get_configuration()["driver"]
+                                                       ["driver_heartbeat_timeout_s"])
+        except KeyError:
+            logger.warning("No valid value for driver: driver_heartbeat_timeout in config_file. Using default "
+                           "value of 30 seconds")
+            self.__driver_heartbeat_timeout = 30
+
+        self._minigame_objects : dict = {}
+        self._available_minigames : list[str] = []
+        for minigame in Minigame_Controller.minigames.keys():
+            self._minigame_objects[minigame] = Minigame_Controller.minigames[minigame](sio, minigame_ui_blueprint)
+            self._available_minigames.append(minigame)
+
+        Minigame_Controller.instance = self
+
+    def get_instance(sio: AsyncServer = None, minigame_ui_blueprint : Blueprint = None) -> "Minigame_Controller":
+        if Minigame_Controller.instance is None:
+            Minigame_Controller.instance = Minigame_Controller(sio = sio, minigame_ui_blueprint = minigame_ui_blueprint)
+        return Minigame_Controller.instance
+
+    def handle_player_removed(self, player_id : str) -> None:
+        """
+        Handle the removal of the specified player from all minigames they are currently associated with.
+        The associated minigames are cancelled.
+
+        Parameters:
+        -----------
+        player_id: str
+            UUID of the player to be removed
+        """
+        for minigame_object in self._minigame_objects.values():
+            if player in minigame_object.get_players():
+                minigame_object.cancel()
+
+    def get_minigame_object(self, minigame : str) -> Minigame:
+        """
+        Get the object/instance of the specified minigame
+
+        Parameters:
+        -----------
+        minigame: str
+            Name of the minigame (class name)
+        """
+        return self._minigame_objects.get(minigame)
+
+    def get_minigame_name_list(self) -> list[str]:
+        """
+        Get a list of the names of all minigames
+
+        Returns:
+        --------
+        list[str]
+            list of names of minigames
+        """
+        return self._minigame_objects.keys()
+
+    def get_description(self, minigame : str) -> str | None:
+        """
+        Returns the description of the specified minigame
+        
+        Parameters:
+        -----------
+        minigame: str
+            The name of the minigame (class name) which's description is to be returned
+
+        Returns:
+        --------
+        str: Description of the minigame as a String
+        None: If the minigame could not be found None will be returned
+        """
+        minigame_object : Minigame = self.get_minigame_object(minigame)
+        if minigame_object is None:
+            return None
+        else:
+            return minigame_object.description()
+
+    def play_random_available_minigame(self, *players : str) -> asyncio.Task | None:
+        """
+        Play a random available minigame with the specified players. 
+
+        Parameters:
+        -----------
+        *players : str
+            IDs of the players that are supposed to play
+        
+        Returns:
+        --------
+        asyncio.Task: Task of the running game. Will return the winner's uuid once finished or None if cancelled
+        None: if the minigame could not be started for some reason
+        """
+        if len(self._available_minigames) == 0:
+            raise Exception("No minigame is currently available.")
+        minigame = random.choice(self._available_minigames)
+
+        return self._play_minigame(minigame, *players)
+
+    def _play_minigame(self, minigame : str, *players : str) -> (asyncio.Task, Minigame) | None:
+        """
+        Create an asyncio of the minigame playing with the specified players.
+
+        Parameters:
+        -----------
+        minigame: str
+            Name of the minigame to play
+        *players : str
+            IDs of the players that are supposed to play
+        
+        Returns:
+        --------
+        (asyncio.Task, Minigame): Task of the running game and object/instance of it. Will return the winner's uuid once finished or None if cancelled
+        None: if the minigame could not be started for some reason
+        """
+        minigame_object : Minigame = self._minigame_objects.get(minigame)
+
+        if minigame_object is None:
+            logger.warning("The selected minigame does not exist.")
+            return None
+
+        if minigame not in self._available_minigames:
+            logger.warning("The selected minigame is not currently available.") 
+            return None
+
+        self._available_minigames.remove(minigame)
+
+        running_game_task : asyncio.Task = asyncio.create_task(minigame_object.play(*players))
+        running_game_task.add_done_callback(self._minigame_done_callback(minigame_object))
+
+        return running_game_task
+
+    def _minigame_done_callback(self, minigame_object : Minigame) -> None:
+        """
+        Callback function to be executed once a minigame is done (completed or cancelled)
+
+        Parameters:
+        -----------
+        minigame_object : Minigame
+            The minigame object/instance that is done
+        """
+        self._available_minigames.append(minigame_object.get_name())

--- a/src/Minigames/Minigame_Test.py
+++ b/src/Minigames/Minigame_Test.py
@@ -29,7 +29,7 @@ class Minigame_Test(Minigame):
 
     async def _play(self, *players : str) -> str:
         if players is None or len(players) < 2:
-            raise Exception(f"Not enough players were given for minigame {self.name}.")
+            raise Exception(f"Not enough players were given for minigame {self.get_name()}.")
         player1 : str = players[0]
         player2 : str = players[1]    
         self._players.clear()

--- a/src/Minigames/Minigame_Test.py
+++ b/src/Minigames/Minigame_Test.py
@@ -10,21 +10,38 @@ from socketio import AsyncServer
 from abc import abstractmethod
 
 class Minigame_Test(Minigame):
+
+
     def __init__(self, sio: AsyncServer, blueprint : Blueprint, name=__name__):
         super().__init__(sio, blueprint, name)
-        self.a = 1
-        self.b = 2
+        self.values : dict = {}
 
+        @self._sio.on('minigame_test_value_submit')
+        def on_value_submit(sid: str, data: dict) -> None:
+            """
+            Store the submitted value of the player in a dict
+            """
+            player = data["player"]
+            self.values[player] = data["value"]
+            print("VALUES", self.values)
+            print("PLAYER", player, "HAS SUBMITTED", data["value"])
         
 
-    async def play(player1 : str, player2 : str = None) -> str:
-        if self.a > self.b:
+    async def play(self, player1 : str, player2 : str = None) -> str:
+        while player1 not in self.values.keys() or player2 not in self.values.keys():
+            await asyncio.sleep(1.0)
+        player1_value : str = self.values[player1]
+        player2_value : str = self.values[player2]
+        print("PLAYER1 VALUE", player1_value, "PLAYER2 VALUE", player2_value)
+        if len(player1_value) > len(player2_value):
             return player1
         else:
             return player2
     
-    def cancel() -> None:
-        pass
+    def cancel(self) -> None:
+        return
 
-    def description() -> str:
-        return "Victory depends on the numbers entered in __init__."
+    def description(self) -> str:
+        return "Longest text = winner"
+
+   

--- a/src/Minigames/Minigame_Test.py
+++ b/src/Minigames/Minigame_Test.py
@@ -1,0 +1,30 @@
+from Minigames.Minigame import Minigame
+
+from quart import Blueprint, render_template, request
+import uuid
+import logging
+import asyncio
+import time
+
+from socketio import AsyncServer
+from abc import abstractmethod
+
+class Minigame_Test(Minigame):
+    def __init__(self, sio: AsyncServer, blueprint : Blueprint, name=__name__):
+        super().__init__(sio, blueprint, name)
+        self.a = 1
+        self.b = 2
+
+        
+
+    async def play(player1 : str, player2 : str = None) -> str:
+        if self.a > self.b:
+            return player1
+        else:
+            return player2
+    
+    def cancel() -> None:
+        pass
+
+    def description() -> str:
+        return "Victory depends on the numbers entered in __init__."

--- a/src/Minigames/Minigame_Test.py
+++ b/src/Minigames/Minigame_Test.py
@@ -27,12 +27,23 @@ class Minigame_Test(Minigame):
             print("PLAYER", player, "HAS SUBMITTED", data["value"])
         
 
-    async def play(self, player1 : str, player2 : str = None) -> str:
+    async def play(self, *players : str) -> str:
+        if players is None or len(players) < 2:
+            raise Exception(f"Not enough players were given for minigame {self.name}.")
+        player1 : str = players[0]
+        player2 : str = players[1]    
+        self._players.clear()
+        self._players.append(player1)
+        self._players.append(player2)
+        self.values.clear()
         while player1 not in self.values.keys() or player2 not in self.values.keys():
             await asyncio.sleep(1.0)
         player1_value : str = self.values[player1]
         player2_value : str = self.values[player2]
         print("PLAYER1 VALUE", player1_value, "PLAYER2 VALUE", player2_value)
+
+        self._players.clear()
+
         if len(player1_value) > len(player2_value):
             return player1
         else:
@@ -44,4 +55,6 @@ class Minigame_Test(Minigame):
     def description(self) -> str:
         return "Longest text = winner"
 
+    def get_players(self) -> list[str]:
+        return self._players.copy()
    

--- a/src/Minigames/Minigame_Test.py
+++ b/src/Minigames/Minigame_Test.py
@@ -27,7 +27,7 @@ class Minigame_Test(Minigame):
             print("PLAYER", player, "HAS SUBMITTED", data["value"])
         
 
-    async def play(self, *players : str) -> str:
+    async def _play(self, *players : str) -> str:
         if players is None or len(players) < 2:
             raise Exception(f"Not enough players were given for minigame {self.name}.")
         player1 : str = players[0]
@@ -48,13 +48,10 @@ class Minigame_Test(Minigame):
             return player1
         else:
             return player2
-    
-    def cancel(self) -> None:
-        return
 
     def description(self) -> str:
         return "Longest text = winner"
 
-    def get_players(self) -> list[str]:
-        return self._players.copy()
-   
+    def cancel(self) -> None:
+        super().cancel()
+        self.values.clear()

--- a/src/UserInterface/DriverUI.py
+++ b/src/UserInterface/DriverUI.py
@@ -35,8 +35,6 @@ class DriverUI:
         self.environment_mng: EnvironmentManager = environment_mng
         self.config_handler: ConfigurationHandler = ConfigurationHandler()
 
-        self.minigame_players : set = set()
-
         self.__latest_driver_heartbeats: dict = {}
         self.__checking_heartbeats_flag: bool = False
 
@@ -68,14 +66,6 @@ class DriverUI:
             background_grace_period = config["driver"]["driver_background_grace_period_s"]
             vehicle_scale = config["environment"]["env_vehicle_scale"]
             player_exists, picture, vehicle_information = self._prepare_html_data(player)
-
-            self.minigame_players.add(player)
-            print("MINGIGAME PLAYERS", self.minigame_players)
-            if len(self.minigame_players) >= 2:
-                minigame_controller = Minigame_Controller.get_instance()
-                print("DRIVER UI PLAYER SET", self.minigame_players)
-                print("DRIVER UI PLAYER LIST", list(self.minigame_players))
-                minigame_controller.play_random_available_minigame(*list(self.minigame_players))
 
             return await render_template(template_name_or_list='driver_index.html', player=player,
                                          player_exists=player_exists,

--- a/src/UserInterface/DriverUI.py
+++ b/src/UserInterface/DriverUI.py
@@ -18,7 +18,8 @@ from socketio import AsyncServer
 from EnvironmentManagement.EnvironmentManager import EnvironmentManager
 from EnvironmentManagement.ConfigurationHandler import ConfigurationHandler
 
-from UserInterface.Minigame_Manager import Minigame_Manager
+from UserInterface.MinigameUI import Minigame_UI
+from Minigames.Minigame_Controller import Minigame_Controller
 from Minigames.Minigame import Minigame
 
 logger = logging.getLogger(__name__)
@@ -71,10 +72,10 @@ class DriverUI:
             self.minigame_players.add(player)
             print("MINGIGAME PLAYERS", self.minigame_players)
             if len(self.minigame_players) >= 2:
-                minigame_manager = Minigame_Manager.getInstance()
+                minigame_controller = Minigame_Controller.get_instance()
                 print("DRIVER UI PLAYER SET", self.minigame_players)
                 print("DRIVER UI PLAYER LIST", list(self.minigame_players))
-                asyncio.create_task(minigame_manager.play_random_available_minigame(*list(self.minigame_players)))
+                minigame_controller.play_random_available_minigame(*list(self.minigame_players))
 
             return await render_template(template_name_or_list='driver_index.html', player=player,
                                          player_exists=player_exists,

--- a/src/UserInterface/DriverUI.py
+++ b/src/UserInterface/DriverUI.py
@@ -18,6 +18,9 @@ from socketio import AsyncServer
 from EnvironmentManagement.EnvironmentManager import EnvironmentManager
 from EnvironmentManagement.ConfigurationHandler import ConfigurationHandler
 
+from UserInterface.Minigame_Manager import Minigame_Manager
+from Minigames.Minigame import Minigame
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,6 +33,8 @@ class DriverUI:
         self._sio: AsyncServer = sio
         self.environment_mng: EnvironmentManager = environment_mng
         self.config_handler: ConfigurationHandler = ConfigurationHandler()
+
+        self.minigame_players : set = set()
 
         self.__latest_driver_heartbeats: dict = {}
         self.__checking_heartbeats_flag: bool = False
@@ -55,6 +60,13 @@ class DriverUI:
             player = request.cookies.get("player")
             if player is None:
                 player = str(uuid.uuid4())
+            
+            self.minigame_players.add(player)
+            print("MINGIGAME PLAYERS", self.minigame_players)
+            if len(self.minigame_players) >= 2:
+                minigame_manager = Minigame_Manager.getInstance()
+                minigame = minigame_manager.get_minigame_object("Minigame_Test")
+                asyncio.create_task(minigame.play(self.minigame_players.pop(), self.minigame_players.pop()))
 
             config = self.config_handler.get_configuration()
 

--- a/src/UserInterface/Minigame.py
+++ b/src/UserInterface/Minigame.py
@@ -1,0 +1,141 @@
+# Copyright 2024 IAV GmbH
+#
+# This file is part of the IAV-Distortion project an interactive
+# and educational showcase designed to demonstrate the need
+# of automotive cybersecurity in a playful, engaging manner.
+# and is released under the "Apache 2.0". Please see the LICENSE
+# file that should have been included as part of this package.
+#
+
+from quart import Blueprint, render_template, request
+import uuid
+import logging
+import asyncio
+import time
+
+from socketio import AsyncServer
+
+from EnvironmentManagement.EnvironmentManager import EnvironmentManager
+from EnvironmentManagement.ConfigurationHandler import ConfigurationHandler
+
+logger = logging.getLogger(__name__)
+
+
+class Minigame:
+
+    def __init__(self, sio: AsyncServer, name=__name__) -> None:
+        self.minigame_ui_blueprint: Blueprint = Blueprint(name='minigameUI_bp', import_name='minigameUI_bp')
+        self._sio: AsyncServer = sio
+
+        async def home_minigame() -> str:
+            """
+            Load the minigame ui page.
+
+            Gets the clients cookie for identification, provides GUI for minigames.
+
+            Returns
+            -------
+                Returns a Response object representing a redirect to the minigame ui page.
+            """
+            player = request.cookies.get("player")
+            if player is None:
+                player = str(uuid.uuid4())
+
+            return await render_template(template_name_or_list='minigame_index.html', player=player)
+            
+        self.minigame_ui_blueprint.add_url_rule('/', 'minigame', view_func=home_minigame)
+
+        async def exit_minigame() -> str:
+            player_id = request.args.get(key='player_id', type=str)
+            reason = request.args.get(key='reason', default="The minigame has been cancelled.", type=str)
+
+            return await render_template(template_name_or_list='driver_exit.html', player=player_id, message=reason)
+
+        self.minigame_ui_blueprint.add_url_rule('/exit', 'exit_driver', view_func=exit_minigame)
+
+        @self._sio.on('handle_connect')
+        def handle_connected(sid: str, data: dict) -> None:
+            """
+            Calls environment manager function to update queues and vehicles.
+
+            Custom event triggered on connection of a client to the driver ui. Event needed to handle reloads of
+            driver ui properly. Receives the player id from client which is used by the environment manager to abort
+            removing of player if reconnected in a certain time (e.g. when reloading the page).
+
+            Parameters
+            ----------
+            sid: str
+                ID of websocket client
+            data: dict
+                Data received with websocket event.
+            """
+            player = data["player"]
+            return
+
+        @self._sio.on('disconnected')
+        def handle_disconnected(sid, data):
+            player = data["player"]
+            logger.debug(f"Driver {player} disconnected!")
+            self.__remove_player(player)
+            return
+
+        @self._sio.on('disconnect')
+        def handle_clienet_disconnect(sid):
+            logger.debug(f"Client {sid} disconnected.")
+            return
+
+    def update_driving_data(self, driving_data: dict) -> None:
+        self.__run_async_task(self.__emit_driving_data(driving_data))
+        return
+
+    def get_blueprint(self) -> Blueprint:
+        return self.minigame_ui_blueprint
+
+    def get_vehicle_by_player(self, player: str):
+        temp_vehicle = [vehicle for vehicle in self.vehicles if vehicle.player == player]
+        if len(temp_vehicle) == 1:
+            return temp_vehicle[0]
+        elif len(temp_vehicle) < 1:
+            return None
+        else:
+            # Todo: define error reaction if same player is assigned to different vehicles
+            return None
+
+    def __run_async_task(self, task):
+        """
+        Run a asyncio awaitable task
+        task: awaitable task
+        """
+        asyncio.create_task(task)
+        # TODO: Log error, if the coroutine doesn't end successfully
+
+    async def __emit_driving_data(self, driving_data: dict) -> None:
+        await self._sio.emit('update_driving_data', driving_data)
+        return
+
+    async def __check_driver_heartbeat_timeout(self):
+        """
+        Continuously checks driver heartbeats for timeouts.
+        """
+        while True:
+            await asyncio.sleep(1)
+            players = list(self.__latest_driver_heartbeats.keys())
+            for player in players:
+                if time.time() - self.__latest_driver_heartbeats.get(player, 0) > self.__driver_heartbeat_timeout:
+                    logger.info(f'Player {player} timed out. Removing player from the game...')
+                    self.__remove_player(player)
+
+    def __remove_player(self, player: str) -> None:
+        """
+        Remove player from the game.
+
+        Parameters
+        ----------
+        player: str
+            ID of player to be removed.
+        """
+        if player in self.__latest_driver_heartbeats:
+            del self.__latest_driver_heartbeats[player]
+        grace_period = self.config_handler.get_configuration()["driver"]["driver_reconnect_grace_period_s"]
+        self.environment_mng.schedule_remove_player_task(player=player, grace_period=grace_period)
+        return

--- a/src/UserInterface/MinigameUI.py
+++ b/src/UserInterface/MinigameUI.py
@@ -7,7 +7,7 @@
 # file that should have been included as part of this package.
 #
 
-from quart import Blueprint, render_template, request
+from quart import Blueprint, render_template, request, redirect, url_for
 import logging
 import asyncio
 from asyncio import Task
@@ -50,9 +50,8 @@ class Minigame_UI:
 
         async def home_minigame() -> str:
             player = request.cookies.get("player")
-            if player is None:
-                #TODO In this case, a player has connected to the minigame page without having connected as a driver before. They should probably notified that they need to drive first.
-                return
+            if player is None or self._minigame_controller.get_minigame_name_by_player_id(player) is None:
+                return redirect(url_for("driverUI_bp.home_driver"))
 
             return await render_template(template_name_or_list='minigame_index.html', player=player, minigame = self._minigame_controller.get_minigame_name_by_player_id(player), heartbeat_interval = self.__driver_heartbeat_timeout)
         
@@ -101,18 +100,6 @@ class Minigame_UI:
 
     def get_blueprint(self) -> Blueprint:
         return self.minigame_ui_blueprint
-
-    def __remove_player(self, player: str) -> None:
-        """
-        Remove player from the minigame.
-
-        Parameters
-        ----------
-        player: str
-            ID of player to be removed.
-        """
-        self._connected_players.remove(player)
-        return
 
     async def _send_description(self, minigame : str) -> None:
         """

--- a/src/UserInterface/MinigameUI.py
+++ b/src/UserInterface/MinigameUI.py
@@ -51,7 +51,7 @@ class Minigame_UI:
                 #TODO In this case, a player has connected to the minigame page without having connected as a driver before. They should probably notified that they need to drive first.
                 return
 
-            return await render_template(template_name_or_list='minigame_index.html', player=player, minigame = minigame, heartbeat_interval = self.__driver_heartbeat_timeout)
+            return await render_template(template_name_or_list='minigame_index.html', player=player, minigame = self._minigame_controller.get_minigame_name_by_player_id(player), heartbeat_interval = self.__driver_heartbeat_timeout)
         
         self.minigame_ui_blueprint.add_url_rule('/', 'minigame', view_func = home_minigame)
 
@@ -81,7 +81,7 @@ class Minigame_UI:
             """
             player = data["player"]
             logger.debug(f"Driver {player} connected to the minigame lobby.")
-            asyncio.create_task(self.send_description(data["minigame"]))
+            asyncio.create_task(self._send_description(data["minigame"]))
             asyncio.create_task(self._sio.enter_room(sid, player))
             return
 

--- a/src/UserInterface/Minigame_Manager.py
+++ b/src/UserInterface/Minigame_Manager.py
@@ -118,7 +118,8 @@ class Minigame_Manager:
             """
             player = request.cookies.get("player")
             if player is None:
-                player = str(uuid.uuid4())
+                #TODO In this case, a player has connected to the minigame page without having connected as a driver before. They should probably notified that they need to drive first.
+                return
 
             return await render_template(template_name_or_list='minigame_index.html', player=player, minigame = minigame)
         

--- a/src/UserInterface/Minigame_Manager.py
+++ b/src/UserInterface/Minigame_Manager.py
@@ -7,7 +7,7 @@
 # file that should have been included as part of this package.
 #
 
-from quart import Blueprint, render_template, request, Quart
+from quart import Blueprint, render_template, request
 import uuid
 import logging
 import asyncio
@@ -15,24 +15,46 @@ import time
 
 from socketio import AsyncServer
 
-from EnvironmentManagement.EnvironmentManager import EnvironmentManager
 from EnvironmentManagement.ConfigurationHandler import ConfigurationHandler
 
-from Minigames import Minigame_Test
+from Minigames.Minigame import Minigame
+from Minigames.Minigame_Test import Minigame_Test
 
 logger = logging.getLogger(__name__)
 
-minigames = {"Minigame_Test" : Minigame_Test.Minigame_Test}
+minigames = {"Minigame_Test" : Minigame_Test}
 
 
 class Minigame_Manager:
 
-    def __init__(self, sio: AsyncServer, quart_app : Quart, name=__name__) -> None:
+    def __init__(self, sio: AsyncServer, name=__name__) -> None:
         self.minigame_ui_blueprint: Blueprint = Blueprint(name='minigameUI_bp', import_name='minigameUI_bp')
         self._sio: AsyncServer = sio
-        self.quart_app = quart_app
+        self.config_handler: ConfigurationHandler = ConfigurationHandler()
         self._connected_players = []
+        
+    
+        try:
+            self.__driver_heartbeat_timeout: int = int(self.config_handler.get_configuration()["driver"]
+                                                       ["driver_heartbeat_timeout_s"])
+        except KeyError:
+            logger.warning("No valid value for driver: driver_heartbeat_timeout in config_file. Using default "
+                           "value of 30 seconds")
+            self.__driver_heartbeat_timeout = 30
 
+        self.minigame_objects : dict = {}
+        for minigame in minigames.keys():
+            self.minigame_objects[minigame] = minigames[minigame](self._sio, self.minigame_ui_blueprint)
+
+        async def home_minigame() -> str:
+            player = request.cookies.get("player")
+            if player is None:
+                #TODO In this case, a player has connected to the minigame page without having connected as a driver before. They should probably notified that they need to drive first.
+                return
+
+            return await render_template(template_name_or_list='minigame_index.html', player=player, minigame = minigame, heartbeat_interval = self.__driver_heartbeat_timeout)
+        
+        self.minigame_ui_blueprint.add_url_rule('/', 'minigame', view_func = home_minigame)
 
         async def exit_minigame() -> str:
             player_id = request.args.get(key='player_id', type=str)
@@ -60,6 +82,8 @@ class Minigame_Manager:
             """
             player = data["player"]
             logger.debug(f"Driver {player} connected to the minigame.")
+            print(data.keys())
+            asyncio.create_task(self.send_description(data["minigame"]))
             return
 
         @self._sio.on('minigame_disconnected')
@@ -73,6 +97,11 @@ class Minigame_Manager:
         def handle_clienet_disconnect(sid):
             logger.debug(f"Client {sid} disconnected from the minigame.")
             return
+
+        Minigame_Manager.instance = self
+
+    def getInstance() -> "Minigame_Manager":
+        return Minigame_Manager.instance
 
     def get_blueprint(self) -> Blueprint:
         return self.minigame_ui_blueprint
@@ -97,33 +126,29 @@ class Minigame_Manager:
         self._connected_players.remove(player)
         return
 
-    def set_minigame(self, minigame : str) -> None:
+    def get_minigame_object(self, minigame : str) -> Minigame:
         """
-        Set the Minigame that is to be played next with this Manager.
+        Get the object/instance of the specified minigame
 
-        Parameters
-        ----------
+        Parameters:
+        -----------
         minigame: str
             Name of the minigame (class name)
         """
-        async def home_minigame() -> str:
-            """
-            Load the minigame ui page.
+        return self.minigame_objects.get(minigame)
 
-            Gets the clients cookie for identification, provides GUI for minigames.
-
-            Returns
-            -------
-                Returns a Response object representing a redirect to the minigame ui page.
-            """
-            player = request.cookies.get("player")
-            if player is None:
-                #TODO In this case, a player has connected to the minigame page without having connected as a driver before. They should probably notified that they need to drive first.
-                return
-
-            return await render_template(template_name_or_list='minigame_index.html', player=player, minigame = minigame)
+    async def send_description(self, minigame : str):
+        """
+        Sends the description of the specified minigame via socketio
         
-        self.minigame_ui_blueprint.add_url_rule('/', 'minigame', view_func = home_minigame)
-        minigame_object = minigames[minigame](self._sio, self.minigame_ui_blueprint)
-
-        self.quart_app.register_blueprint(self.minigame_ui_blueprint, url_prefix = "/minigame")
+        Parameters:
+        -----------
+        minigame: str
+            The name of the minigame (class name) which's description is to be sent
+        """
+        minigame_object : Minigame = self.get_minigame_object(minigame)
+        if minigame_object is None:
+            description = "This minigame could not be found."
+        else:
+            description = minigame_object.description()
+        await self._sio.emit("send_description", {"minigame": minigame, "description": description})

--- a/src/UserInterface/Minigame_Manager.py
+++ b/src/UserInterface/Minigame_Manager.py
@@ -251,7 +251,7 @@ class Minigame_Manager:
         print("WINNER", winner)
         self._available_minigames.append(minigame)
         
-        await asyncio.sleep(2)
+        await asyncio.sleep(1)
         await self.redirect_to_driver_ui(*actually_playing)
 
         return winner
@@ -261,19 +261,16 @@ class Minigame_Manager:
         Redirects the specified players from the driver UI to the minigame UI.
         """
         for room in players:
-            if room is None:
-                continue
             await self._sio.emit("redirect_to_minigame_ui", to=room)
 
     async def redirect_to_driver_ui(self, *players : str) -> None:
         """
         Redirects the specified players from the minigame UI to the driver UI.
         """
-        for room in players:
-            print(f"REDIRECTING {room} to driver UI")
-            if room is None:
-                continue
-            await self._sio.emit("redirect_to_driver_ui", to=room)
+        data = {}
+        for i, player in enumerate(players):
+            data[f"player{i}"] = player
+        await self._sio.emit("redirect_to_driver_ui", data = data)
 
     def make_vehicles_drive_continuously(self, *players : str) -> None:
         """

--- a/src/UserInterface/StaffUI.py
+++ b/src/UserInterface/StaffUI.py
@@ -20,7 +20,6 @@ from socketio import AsyncServer
 
 from CyberSecurityManager.CyberSecurityManager import CyberSecurityManager
 from EnvironmentManagement.EnvironmentManager import EnvironmentManager
-from UserInterface.Minigame_Manager import Minigame_Manager
 
 logger = logging.getLogger(__name__)
 
@@ -102,9 +101,6 @@ class StaffUI:
             """
             names, descriptions = self.sort_scenarios()
             active_scenarios = cybersecurity_mng.get_active_hacking_scenarios()  # {'UUID': 'scenarioID'}
-
-            # TODO: This task should be started in Minigame_Manager.py. But the asyncio event loop has not been created during its __init__
-            asyncio.create_task(Minigame_Manager.getInstance().checK_players_still_connected())
 
             # TODO: Show selection of choose hacking scenarios always sorted by player number
             return await render_template('staff_control.html', activeScenarios=active_scenarios,

--- a/src/UserInterface/StaffUI.py
+++ b/src/UserInterface/StaffUI.py
@@ -20,6 +20,7 @@ from socketio import AsyncServer
 
 from CyberSecurityManager.CyberSecurityManager import CyberSecurityManager
 from EnvironmentManagement.EnvironmentManager import EnvironmentManager
+from UserInterface.Minigame_Manager import Minigame_Manager
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +102,10 @@ class StaffUI:
             """
             names, descriptions = self.sort_scenarios()
             active_scenarios = cybersecurity_mng.get_active_hacking_scenarios()  # {'UUID': 'scenarioID'}
+
+            # TODO: This task should be started in Minigame_Manager.py. But the asyncio event loop has not been created during its __init__
+            asyncio.create_task(Minigame_Manager.getInstance().checK_players_still_connected())
+
             # TODO: Show selection of choose hacking scenarios always sorted by player number
             return await render_template('staff_control.html', activeScenarios=active_scenarios,
                                          uuids=environment_mng.get_controlled_cars_list(), names=names,

--- a/src/UserInterface/templates/Minigame_Test.html
+++ b/src/UserInterface/templates/Minigame_Test.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        Hello World
+    </body>
+</html>

--- a/src/UserInterface/templates/Minigame_Test.html
+++ b/src/UserInterface/templates/Minigame_Test.html
@@ -21,7 +21,26 @@
 </head>
 <body>
 
-    Hello World
+    <input type="text" id="textInput">
 
+    <script type="text/javascript" charset="utf-8">
+    
+        var socket = io.connect('http://' + document.domain + ':' + location.port);  
+
+        socket.on('connect', () => {
+            socket.emit('minigame_test_handle_connect', {player: '{{ player }}'});
+            console.log('Websocket connected');
+        });
+
+        window.onunload = function() {
+            socket.emit('minigame_test_disconnected', {player: '{{ player }}'});
+        }
+
+        textInput = document.getElementById("textInput");
+        textInput.onchange = function(){
+            socket.emit('minigame_test_value_submit', {player: '{{ player }}', value: textInput.value})
+        }
+
+    </script>
 </body>
 </html>

--- a/src/UserInterface/templates/Minigame_Test.html
+++ b/src/UserInterface/templates/Minigame_Test.html
@@ -1,5 +1,27 @@
-<html>
-    <body>
-        Hello World
-    </body>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Driver {{player}}</title>
+
+    <!-- general style sheet -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='general.css')}}"/> <!-- to include stylesheet when running webinterface with flask -->
+	<link rel="stylesheet" href="../static/general.css"/> <!-- link to stylesheet for development for working preview -->
+
+    <!-- custom header stylesheet -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='custom_header.css')}}"/> <!-- to include stylesheet when running webinterface with flask -->
+	<link rel="stylesheet" href="../static/custom_header.css"/> <!-- link to stylesheet for development for working preview -->
+
+    <link rel="stylesheet" href="{{ url_for('static', filename='driver.css')}}"/> <!-- to include stylesheet when running webinterface with flask -->
+	<link rel="stylesheet" href="../static/driver.css"/> <!-- link to stylesheet for development for working preview -->
+
+    <!-- Include socket.io library -->
+    <script src="{{ url_for('static', filename='external_resources/socketio/4.7.5/socket.io.js')}}" ></script>
+ 
+</head>
+<body>
+
+    Hello World
+
+</body>
 </html>

--- a/src/UserInterface/templates/driver_index.html
+++ b/src/UserInterface/templates/driver_index.html
@@ -86,7 +86,7 @@
 
         var socket = io.connect('http://' + document.domain + ':' + location.port);
 
-        document.cookie = "player={{ player }}";
+        document.cookie = "player={{ player }};path=/";
 
         <!-- slider to control velocity-->
 

--- a/src/UserInterface/templates/driver_index.html
+++ b/src/UserInterface/templates/driver_index.html
@@ -204,6 +204,10 @@
             }
         });
 
+        socket.on('redirect_to_minigame_ui', function() {
+            window.location = 'http://' + document.domain + ':' + location.port + '/minigame';
+        });
+
     </script>
 
 </body>

--- a/src/UserInterface/templates/minigame_index.html
+++ b/src/UserInterface/templates/minigame_index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Driver {{player}}</title>
+
+    <!-- general style sheet -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='general.css')}}"/> <!-- to include stylesheet when running webinterface with flask -->
+	<link rel="stylesheet" href="../static/general.css"/> <!-- link to stylesheet for development for working preview -->
+
+    <!-- custom header stylesheet -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='custom_header.css')}}"/> <!-- to include stylesheet when running webinterface with flask -->
+	<link rel="stylesheet" href="../static/custom_header.css"/> <!-- link to stylesheet for development for working preview -->
+
+    <link rel="stylesheet" href="{{ url_for('static', filename='driver.css')}}"/> <!-- to include stylesheet when running webinterface with flask -->
+	<link rel="stylesheet" href="../static/driver.css"/> <!-- link to stylesheet for development for working preview -->
+
+    <!-- Include socket.io library -->
+    <script src="{{ url_for('static', filename='external_resources/socketio/4.7.5/socket.io.js')}}" ></script>
+
+</head>
+<body>
+
+    
+    <div class="overlay" id="infoBoxOverlay">
+        <div class="info-box">
+            <div class="info-title">
+                <h2>How to play</h2>
+            </div>
+            <p id="infoBoxContent"> blabla
+            </p>
+            <!-- TODO: Send accept to backend -->
+            <button class="close_tab_button" id="accept_button"> <span class="reload_symbol">&#10004;	</span> I understand the rules.</button>
+        </div>
+    </div>
+    
+    <div class="flexbox-container custom_header">
+        <p class="header">Player {{player}}</p>
+        <img id="logo" src="{{ url_for('static', filename='images/IAV-Logo-White.svg') }}" onerror="this.onerror=null; this.src='{{ url_for('static', filename='images/blank.png') }}'" >
+    </div>
+
+    <div class="flexbox-container flexbox-controls" id="control">    
+        
+    </div>
+
+
+    <script type="text/javascript" charset="utf-8">
+
+
+        var socket = io.connect('http://' + document.domain + ':' + location.port);
+
+        document.cookie = "player={{ player }}";
+
+        window.onload = function() {
+            accept_button = document.getElementById("accept_button");
+            accept_button.onclick = function(){
+                document.getElementById("infoBoxOverlay").style.display = "none";
+                socket.emit('player_accept', {player: '{{player}}'});
+                
+            };
+        }
+        <!-- loading window -->
+        
+
+        socket.on('connect', () => {
+            socket.emit('handle_connect', {player: '{{ player }}'});
+            console.log('Websocket connected');
+        });
+
+
+        window.onunload = function() {
+            socket.emit('disconnected', {player: '{{ player }}'});
+        }
+
+
+        function show_hacked_info(active_hacking_scenario){
+          if(active_hacking_scenario == "0") {
+            document.getElementById("hackedInfo").style.display = "none";
+          }
+          else {
+            document.getElementById("hackedInfo").style.display = "block";
+          }
+        };
+
+        socket.on('player_active', function(data) {
+            if (data == "{{ player }}") {
+                window.location.reload();
+            }
+        });
+
+        socket.on('player_removed', function(data) {
+            if (data.player_id == "{{ player }}") {
+
+                var baseUrl = 'http://' + document.domain + ':' + location.port + '/driver/exit';
+                var player = data.player_id;
+                var reason = data.message;
+
+                var fullUrl = baseUrl + "?player_id=" + encodeURIComponent(player) + "&reason=" + encodeURIComponent(reason);
+                window.location.href = fullUrl;
+            }
+        });
+
+        document.addEventListener('visibilitychange', function() {
+            console.log(document.visibilityState);
+            if (document.visibilityState === 'hidden') {
+                // e.g. changed to different tab
+                socket.emit('driver_inactive', {player: '{{player}}'});
+            }
+            else {
+            // The page is visible again
+                socket.emit('driver_active', {player: '{{player}}'});
+            }
+        });
+
+    </script>
+
+</body>
+</html>

--- a/src/UserInterface/templates/minigame_index.html
+++ b/src/UserInterface/templates/minigame_index.html
@@ -61,8 +61,6 @@
 
         var socket = io.connect('http://' + document.domain + ':' + location.port);
 
-        document.cookie = "player={{ player }}";
-
         window.onload = function() {
             accept_button = document.getElementById("accept_button");
             accept_button.onclick = function(){

--- a/src/UserInterface/templates/minigame_index.html
+++ b/src/UserInterface/templates/minigame_index.html
@@ -30,7 +30,7 @@
             <div class="info-title">
                 <h2>How to play</h2>
             </div>
-            <p id="infoBoxContent"> blabla
+            <p id="infoBoxContent"> A description of the Minigame should have appeared here...
             </p>
             <!-- TODO: Send accept to backend -->
             <button class="close_tab_button" id="accept_button"> <span class="reload_symbol">&#10004;	</span> I understand the rules.</button>
@@ -48,15 +48,14 @@
 
 
     <script type="text/javascript" charset="utf-8">
-        //Include the current Minigame's html
-        jQuery(document).ready(function(){
-            minigame = jQuery("#current-Minigame").attr("name");
-            alert(minigame);
-            jQuery("#current-Minigame").load("{{ url_for('minigameUI_bp.' + minigame)}}", function(response, status){
-                if(status === 'error'){
-                    alert("Failed to load minigameUI_bp.Minigame_Test");
-                }
-            });
+        const minigame = jQuery("#current-Minigame").attr("name");
+
+        //Include the current Minigame's htm       
+        alert(minigame);
+        jQuery("#current-Minigame").load("{{ url_for('minigameUI_bp.' + minigame)}}", function(response, status){
+            if(status === 'error'){
+                alert("Failed to load minigameUI_bp.Minigame_Test");
+            }
         });
 
         var socket = io.connect('http://' + document.domain + ':' + location.port);
@@ -69,11 +68,14 @@
                 
             };
         }
-        <!-- loading window -->
+       
+        setInterval(function(){
+            socket.emit('driver_heartbeat', {player: '{{ player }}'});
+        }, {{ heartbeat_interval }});
         
-
+        console.log(minigame);
         socket.on('connect', () => {
-            socket.emit('minigame_handle_connect', {player: '{{ player }}'});
+            socket.emit('minigame_handle_connect', {player: '{{ player }}', minigame: minigame});
             console.log('Websocket connected');
         });
 
@@ -81,6 +83,14 @@
         window.onunload = function() {
             socket.emit('minigame_disconnected', {player: '{{ player }}'});
         }
+
+        socket.on('send_description', (data) => {
+            if (data.minigame != minigame)
+                return;
+
+            descriptionElement = document.getElementById("infoBoxContent");
+            descriptionElement.textContent = data.description;
+        })
 
     </script>
 

--- a/src/UserInterface/templates/minigame_index.html
+++ b/src/UserInterface/templates/minigame_index.html
@@ -51,7 +51,6 @@
         const minigame = jQuery("#current-Minigame").attr("name");
 
         //Include the current Minigame's htm       
-        alert(minigame);
         jQuery("#current-Minigame").load("{{ url_for('minigameUI_bp.' + minigame)}}", function(response, status){
             if(status === 'error'){
                 alert("Failed to load minigameUI_bp.Minigame_Test");
@@ -92,10 +91,11 @@
             descriptionElement.textContent = data.description;
         })
 
-        socket.on('redirect_to_driver_ui', function() {
-            console.log("REDIRECT TO DRIVER UI");
+        socket.on('redirect_to_driver_ui', (data) => {
+            if (Object.values(data).indexOf('{{ player }}') == -1)
+                return
             window.location = 'http://' + document.domain + ':' + location.port + '/driver';
-        });
+        }); 
 
     </script>
 

--- a/src/UserInterface/templates/minigame_index.html
+++ b/src/UserInterface/templates/minigame_index.html
@@ -55,7 +55,7 @@
             accept_button = document.getElementById("accept_button");
             accept_button.onclick = function(){
                 document.getElementById("infoBoxOverlay").style.display = "none";
-                socket.emit('player_accept', {player: '{{player}}'});
+                socket.emit('minigame_player_accept', {player: '{{player}}'});
                 
             };
         }
@@ -63,54 +63,14 @@
         
 
         socket.on('connect', () => {
-            socket.emit('handle_connect', {player: '{{ player }}'});
+            socket.emit('minigame_handle_connect', {player: '{{ player }}'});
             console.log('Websocket connected');
         });
 
 
         window.onunload = function() {
-            socket.emit('disconnected', {player: '{{ player }}'});
+            socket.emit('minigame_disconnected', {player: '{{ player }}'});
         }
-
-
-        function show_hacked_info(active_hacking_scenario){
-          if(active_hacking_scenario == "0") {
-            document.getElementById("hackedInfo").style.display = "none";
-          }
-          else {
-            document.getElementById("hackedInfo").style.display = "block";
-          }
-        };
-
-        socket.on('player_active', function(data) {
-            if (data == "{{ player }}") {
-                window.location.reload();
-            }
-        });
-
-        socket.on('player_removed', function(data) {
-            if (data.player_id == "{{ player }}") {
-
-                var baseUrl = 'http://' + document.domain + ':' + location.port + '/driver/exit';
-                var player = data.player_id;
-                var reason = data.message;
-
-                var fullUrl = baseUrl + "?player_id=" + encodeURIComponent(player) + "&reason=" + encodeURIComponent(reason);
-                window.location.href = fullUrl;
-            }
-        });
-
-        document.addEventListener('visibilitychange', function() {
-            console.log(document.visibilityState);
-            if (document.visibilityState === 'hidden') {
-                // e.g. changed to different tab
-                socket.emit('driver_inactive', {player: '{{player}}'});
-            }
-            else {
-            // The page is visible again
-                socket.emit('driver_active', {player: '{{player}}'});
-            }
-        });
 
     </script>
 

--- a/src/UserInterface/templates/minigame_index.html
+++ b/src/UserInterface/templates/minigame_index.html
@@ -92,6 +92,11 @@
             descriptionElement.textContent = data.description;
         })
 
+        socket.on('redirect_to_driver_ui', function() {
+            console.log("REDIRECT TO DRIVER UI");
+            window.location = 'http://' + document.domain + ':' + location.port + '/driver';
+        });
+
     </script>
 
 </body>

--- a/src/UserInterface/templates/minigame_index.html
+++ b/src/UserInterface/templates/minigame_index.html
@@ -18,6 +18,9 @@
     <!-- Include socket.io library -->
     <script src="{{ url_for('static', filename='external_resources/socketio/4.7.5/socket.io.js')}}" ></script>
 
+    <!-- Include jqeury -->
+    <script src="{{ url_for('static', filename='external_resources/jquery-3.7.1.min.js')}}"></script>
+
 </head>
 <body>
 
@@ -40,12 +43,21 @@
     </div>
 
     <div class="flexbox-container flexbox-controls" id="control">    
-        
+        <div id="current-Minigame" name="{{minigame}}"></div>
     </div>
 
 
     <script type="text/javascript" charset="utf-8">
-
+        //Include the current Minigame's html
+        jQuery(document).ready(function(){
+            minigame = jQuery("#current-Minigame").attr("name");
+            alert(minigame);
+            jQuery("#current-Minigame").load("{{ url_for('minigameUI_bp.' + minigame)}}", function(response, status){
+                if(status === 'error'){
+                    alert("Failed to load minigameUI_bp.Minigame_Test");
+                }
+            });
+        });
 
         var socket = io.connect('http://' + document.domain + ':' + location.port);
 

--- a/src/UserInterface/templates/minigame_index.html
+++ b/src/UserInterface/templates/minigame_index.html
@@ -48,7 +48,7 @@
 
 
     <script type="text/javascript" charset="utf-8">
-        const minigame = jQuery("#current-Minigame").attr("name");
+        const minigame = "{{ minigame }}";
 
         //Include the current Minigame's htm       
         jQuery("#current-Minigame").load("{{ url_for('minigameUI_bp.' + minigame)}}", function(response, status){

--- a/src/UserInterface/templates/staff_control.html
+++ b/src/UserInterface/templates/staff_control.html
@@ -97,6 +97,10 @@
         header_uuid.innerText = 'UUID';
         header_row.appendChild(header_uuid);
 
+        var header_play_minigame = document.createElement('th');
+        header_play_minigame.innerText = 'Minigame';
+        header_row.appendChild(header_play_minigame);
+
         thead.appendChild(header_row);
         uuids_table.appendChild(thead);
 
@@ -108,6 +112,8 @@
             let cell_player = document.createElement('td');
             let cell_uuid = document.createElement('td');
             let cell_del = document.createElement('td');
+            let cell_play_minigame = document.createElement('td');
+            let playMinigame = document.createElement('button');
             let delPlayerButton = document.createElement('button');
             let delVehicleButton = document.createElement('button');
             delPlayerButton.textContent = 'Remove Player';
@@ -126,6 +132,12 @@
                 }
             };
 
+            playMinigame.textContent = 'Queue up for minigame';
+            playMinigame.className = 'button_small button_pink'
+            playMinigame.onclick = function(){
+                queue_up_for_minigame(c_map.player);
+            };
+
             cell_player.innerText = c_map.player;
             cell_uuid.innerText = c_map.car;
 
@@ -134,7 +146,7 @@
             row.appendChild(cell_uuid);
             row.appendChild(delPlayerButton);
             row.appendChild(delVehicleButton);
-
+            row.appendChild(playMinigame)
 
             uuids_table.appendChild(row);
         }
@@ -146,7 +158,6 @@
             var cell_player = document.createElement('td');
             var cell_uuid = document.createElement('td');
             let delPlayerButton = document.createElement('button');
-
             delPlayerButton.textContent = 'Remove Player';
             delPlayerButton.className = 'button_small button_pink'
             delPlayerButton.onclick = function(){
@@ -170,7 +181,6 @@
 
             var cell_player = document.createElement('td');
             var cell_uuid = document.createElement('td');
-
             let delVehicleButton = document.createElement('button');
             delVehicleButton.textContent = 'Remove Vehicle';
             delVehicleButton.className = 'button_small button_pink'
@@ -192,6 +202,11 @@
 
        socket.emit('get_update_hacking_scenarios');
     });
+
+    function queue_up_for_minigame(player){
+        console.log("PLAYER " + player + " has queued up to play a minigame")
+        socket.emit('queue_up_for_minigame', player)
+    }
 
     /**
     * Handles 'update_hacking_scenarios' event.

--- a/src/config_file.json
+++ b/src/config_file.json
@@ -93,5 +93,8 @@
 			"length": 349,
 			"diameter": 184
 		}
-	]
+	],
+	"minigame" : {
+		"driving_speed_while_playing" : 30
+	}
 }

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,8 @@ from CyberSecurityManager.CyberSecurityManager import CyberSecurityManager
 from UserInterface.DriverUI import DriverUI
 from UserInterface.StaffUI import StaffUI
 from UserInterface.CarMap import CarMap
-from UserInterface.Minigame import Minigame
+from UserInterface.Minigame_Manager import Minigame_Manager
+from Minigames.Minigame_Test import Minigame_Test
 
 from quart import Quart
 from socketio import AsyncServer, ASGIApp
@@ -63,9 +64,10 @@ def create_app(admin_password: str):
     car_map = CarMap(environment_manager=environment_mng, sio=socket)
     car_map_blueprint = car_map.get_blueprint()
 
-    minigame_ui = Minigame(sio=socket)
+    minigame_ui = Minigame_Manager(sio=socket)
     minigame_ui_blueprint = minigame_ui.get_blueprint()
 
+    Minigame_Test(sio=socket, blueprint=minigame_ui_blueprint)  
     quart_app.register_blueprint(minigame_ui_blueprint, url_prefix='/minigame')
 
     quart_app.register_blueprint(car_map_blueprint, url_prefix='/car_map')

--- a/src/main.py
+++ b/src/main.py
@@ -64,7 +64,7 @@ def create_app(admin_password: str):
     car_map = CarMap(environment_manager=environment_mng, sio=socket)
     car_map_blueprint = car_map.get_blueprint()
 
-    minigame_ui = Minigame_Manager(sio=socket)
+    minigame_ui = Minigame_Manager(sio=socket, environment_mng=environment_mng, behaviour_ctrl=behaviour_ctrl)
     minigame_ui_blueprint = minigame_ui.get_blueprint()
 
     quart_app.register_blueprint(car_map_blueprint, url_prefix='/car_map')

--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,7 @@ from CyberSecurityManager.CyberSecurityManager import CyberSecurityManager
 from UserInterface.DriverUI import DriverUI
 from UserInterface.StaffUI import StaffUI
 from UserInterface.CarMap import CarMap
+from UserInterface.Minigame import Minigame
 
 from quart import Quart
 from socketio import AsyncServer, ASGIApp
@@ -61,6 +62,12 @@ def create_app(admin_password: str):
 
     car_map = CarMap(environment_manager=environment_mng, sio=socket)
     car_map_blueprint = car_map.get_blueprint()
+
+    minigame_ui = Minigame(sio=socket)
+    minigame_ui_blueprint = minigame_ui.get_blueprint()
+
+    quart_app.register_blueprint(minigame_ui_blueprint, url_prefix='/minigame')
+
     quart_app.register_blueprint(car_map_blueprint, url_prefix='/car_map')
 
     quart_app.register_blueprint(driver_ui_blueprint, url_prefix='/driver')

--- a/src/main.py
+++ b/src/main.py
@@ -19,8 +19,7 @@ from CyberSecurityManager.CyberSecurityManager import CyberSecurityManager
 from UserInterface.DriverUI import DriverUI
 from UserInterface.StaffUI import StaffUI
 from UserInterface.CarMap import CarMap
-from UserInterface.Minigame_Manager import Minigame_Manager
-from Minigames.Minigame_Test import Minigame_Test
+from UserInterface.MinigameUI import Minigame_UI
 
 from quart import Quart
 from socketio import AsyncServer, ASGIApp
@@ -64,7 +63,7 @@ def create_app(admin_password: str):
     car_map = CarMap(environment_manager=environment_mng, sio=socket)
     car_map_blueprint = car_map.get_blueprint()
 
-    minigame_ui = Minigame_Manager(sio=socket, environment_mng=environment_mng, behaviour_ctrl=behaviour_ctrl)
+    minigame_ui = Minigame_UI(sio=socket, environment_mng=environment_mng, behaviour_ctrl=behaviour_ctrl)
     minigame_ui_blueprint = minigame_ui.get_blueprint()
 
     quart_app.register_blueprint(car_map_blueprint, url_prefix='/car_map')

--- a/src/main.py
+++ b/src/main.py
@@ -64,11 +64,10 @@ def create_app(admin_password: str):
     car_map = CarMap(environment_manager=environment_mng, sio=socket)
     car_map_blueprint = car_map.get_blueprint()
 
-    minigame_ui = Minigame_Manager(sio=socket)
+    minigame_ui = Minigame_Manager(sio=socket, quart_app=quart_app)
     minigame_ui_blueprint = minigame_ui.get_blueprint()
 
-    Minigame_Test(sio=socket, blueprint=minigame_ui_blueprint)  
-    quart_app.register_blueprint(minigame_ui_blueprint, url_prefix='/minigame')
+    minigame_ui.set_minigame("Minigame_Test")
 
     quart_app.register_blueprint(car_map_blueprint, url_prefix='/car_map')
 

--- a/src/main.py
+++ b/src/main.py
@@ -64,15 +64,15 @@ def create_app(admin_password: str):
     car_map = CarMap(environment_manager=environment_mng, sio=socket)
     car_map_blueprint = car_map.get_blueprint()
 
-    minigame_ui = Minigame_Manager(sio=socket, quart_app=quart_app)
+    minigame_ui = Minigame_Manager(sio=socket)
     minigame_ui_blueprint = minigame_ui.get_blueprint()
-
-    minigame_ui.set_minigame("Minigame_Test")
 
     quart_app.register_blueprint(car_map_blueprint, url_prefix='/car_map')
 
     quart_app.register_blueprint(driver_ui_blueprint, url_prefix='/driver')
     quart_app.register_blueprint(staff_ui_blueprint, url_prefix='/staff')
+
+    quart_app.register_blueprint(minigame_ui_blueprint, url_prefix = "/minigame")
 
     return quart_app, socket
 


### PR DESCRIPTION
#13 

Drivers that are playing are not made invulnerable to other hacking attacks yet, because hacking attacks are in another branch.

Players can be sent to play a minigame via the Singleton Minigame_Controller. This will redirect all players from the driver UI to the minigame UI. Their cars will be set to drive at 30% speed. In the minigame UI the selected minigame will be loaded with a short description/how to play as a popup. Once the minigame is finished (in the test minigame: both players have submitted a string via the input box) or the minigame is cancelled (currently happens when at least one player gets disconnected (via idle or manually via staff)) a socketio event is sent to all players to be redirected to the driver ui. The winner is returned by the asyncio task created by Minigame_Controller.

The Staff UI contains buttons for all players with assigned vehicles to queue them up for a minigame.

Currently there is only one "lobby" for each minigame. Currently there is only one minigame "Minigame_Test". While two players are playing this minigame, no other minigames can currently be started, because they are linked to certain url-rules. When we have 2 or more minigames, this should not be an issue.    